### PR TITLE
Lexer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module monkey
+
+go 1.17

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,0 +1,58 @@
+package lexer
+
+import "monkey/token"
+
+type Lexer struct{
+	input 			string
+	position		int
+	readPosition	int
+	ch				byte
+}
+
+func New(input string) *Lexer{
+	l := &Lexer{input: input}
+	l.readChar()
+	return l
+}
+
+func (l *Lexer) readChar(){
+	if l.readPosition >= len(l.input) {
+		l.ch = 0
+	}else{
+		l.ch = l.input[l.readPosition]
+	}
+	l.position = l.readPosition
+	l.readPosition += 1
+}
+
+func (l *Lexer) NextToken() token.Token{
+	var tok token.Token
+
+	switch l.ch {
+	case '=':
+		tok = newToken(token.ASSIGN, l.ch)
+	case ';':
+		tok = newToken(token.SEMICOLON, l.ch)
+	case '(':
+		tok = newToken(token.LPAREN, l.ch)
+	case ')':
+		tok = newToken(token.RPAREN, l.ch)
+	case '{':
+		tok = newToken(token.LBRACE, l.ch)
+	case '}':
+		tok = newToken(token.RBRACE, l.ch)
+	case ',':
+		tok = newToken(token.COMMA,l.ch)
+	case '+':
+		tok = newToken(token.PLUS, l.ch)
+	case 0:
+		tok.Literal=""
+		tok.Type=token.EOF
+	}
+	l.readChar()
+	return tok
+}
+
+func newToken(tokenType token.TokenType, ch byte) token.Token {
+	return token.Token{Type:tokenType, Literal: string(ch)}
+}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -25,6 +25,15 @@ func (l *Lexer) readChar(){
 	l.readPosition += 1
 }
 
+func (l *Lexer) peekChar() byte {
+	if l.readPosition >= len(l.input) {
+		return 0
+	} else{
+		return l.input[l.readPosition]
+	}
+
+}
+
 func (l *Lexer) NextToken() token.Token{
 	var tok token.Token
 
@@ -32,7 +41,14 @@ func (l *Lexer) NextToken() token.Token{
 
 	switch l.ch {
 	case '=':
-		tok = newToken(token.ASSIGN, l.ch)
+		if l.peekChar()=='='{
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.EQ, Literal: literal}
+		} else{
+			tok = newToken(token.ASSIGN, l.ch)
+		}
 	case ';':
 		tok = newToken(token.SEMICOLON, l.ch)
 	case '(':
@@ -47,6 +63,26 @@ func (l *Lexer) NextToken() token.Token{
 		tok = newToken(token.COMMA,l.ch)
 	case '+':
 		tok = newToken(token.PLUS, l.ch)
+	case '-':
+		tok = newToken(token.MINUS, l.ch)
+	case '/':
+		tok = newToken(token.SLASH, l.ch)
+	case '!':
+		if l.peekChar()=='='{
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.NOT_EQ, Literal: literal}
+		} else{
+			tok = newToken(token.BANG, l.ch)
+		}
+		
+	case '*':
+		tok = newToken(token.ASTERISK, l.ch)
+	case '<':
+		tok = newToken(token.LT, l.ch)
+	case '>':
+		tok = newToken(token.GT, l.ch)
 	case 0:
 		tok.Literal="";
 		tok.Type=token.EOF;

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -2,23 +2,23 @@ package lexer
 
 import "monkey/token"
 
-type Lexer struct{
-	input 			string
-	position		int
-	readPosition	int
-	ch				byte
+type Lexer struct {
+	input        string
+	position     int
+	readPosition int
+	ch           byte
 }
 
-func New(input string) *Lexer{
+func New(input string) *Lexer {
 	l := &Lexer{input: input}
 	l.readChar()
 	return l
 }
 
-func (l *Lexer) readChar(){
+func (l *Lexer) readChar() {
 	if l.readPosition >= len(l.input) {
 		l.ch = 0
-	}else{
+	} else {
 		l.ch = l.input[l.readPosition]
 	}
 	l.position = l.readPosition
@@ -28,25 +28,25 @@ func (l *Lexer) readChar(){
 func (l *Lexer) peekChar() byte {
 	if l.readPosition >= len(l.input) {
 		return 0
-	} else{
+	} else {
 		return l.input[l.readPosition]
 	}
 
 }
 
-func (l *Lexer) NextToken() token.Token{
+func (l *Lexer) NextToken() token.Token {
 	var tok token.Token
 
 	l.skipWhitespace()
 
 	switch l.ch {
 	case '=':
-		if l.peekChar()=='='{
+		if l.peekChar() == '=' {
 			ch := l.ch
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok = token.Token{Type: token.EQ, Literal: literal}
-		} else{
+		} else {
 			tok = newToken(token.ASSIGN, l.ch)
 		}
 	case ';':
@@ -60,7 +60,7 @@ func (l *Lexer) NextToken() token.Token{
 	case '}':
 		tok = newToken(token.RBRACE, l.ch)
 	case ',':
-		tok = newToken(token.COMMA,l.ch)
+		tok = newToken(token.COMMA, l.ch)
 	case '+':
 		tok = newToken(token.PLUS, l.ch)
 	case '-':
@@ -68,15 +68,15 @@ func (l *Lexer) NextToken() token.Token{
 	case '/':
 		tok = newToken(token.SLASH, l.ch)
 	case '!':
-		if l.peekChar()=='='{
+		if l.peekChar() == '=' {
 			ch := l.ch
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok = token.Token{Type: token.NOT_EQ, Literal: literal}
-		} else{
+		} else {
 			tok = newToken(token.BANG, l.ch)
 		}
-		
+
 	case '*':
 		tok = newToken(token.ASTERISK, l.ch)
 	case '<':
@@ -84,18 +84,18 @@ func (l *Lexer) NextToken() token.Token{
 	case '>':
 		tok = newToken(token.GT, l.ch)
 	case 0:
-		tok.Literal="";
-		tok.Type=token.EOF;
+		tok.Literal = ""
+		tok.Type = token.EOF
 	default:
-		if isLetter(l.ch){
+		if isLetter(l.ch) {
 			tok.Literal = l.readIdentifier()
 			tok.Type = token.LookupIdent(tok.Literal)
 			return tok
-		} else if isDigit(l.ch){
+		} else if isDigit(l.ch) {
 			tok.Type = token.INT
 			tok.Literal = l.readNumber()
 			return tok
-		} else{
+		} else {
 			tok = newToken(token.ILLEGAL, l.ch)
 		}
 	}
@@ -103,7 +103,7 @@ func (l *Lexer) NextToken() token.Token{
 	return tok
 }
 
-func (l *Lexer) readIdentifier() string{
+func (l *Lexer) readIdentifier() string {
 	position := l.position
 	for isLetter(l.ch) {
 		l.readChar()
@@ -112,16 +112,16 @@ func (l *Lexer) readIdentifier() string{
 }
 
 func isLetter(ch byte) bool {
-	return 'a' <= ch && ch <='z' || 'A' <= ch && ch<='Z' ||ch=='_'
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
 }
 
 func (l *Lexer) skipWhitespace() {
-	for l.ch == ' '|| l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
+	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
 		l.readChar()
 	}
 }
 
-func (l *Lexer) readNumber() string{
+func (l *Lexer) readNumber() string {
 	position := l.position
 	for isDigit(l.ch) {
 		l.readChar()
@@ -134,5 +134,5 @@ func isDigit(ch byte) bool {
 }
 
 func newToken(tokenType token.TokenType, ch byte) token.Token {
-	return token.Token{Type:tokenType, Literal: string(ch)}
+	return token.Token{Type: tokenType, Literal: string(ch)}
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -28,6 +28,8 @@ func (l *Lexer) readChar(){
 func (l *Lexer) NextToken() token.Token{
 	var tok token.Token
 
+	l.skipWhitespace()
+
 	switch l.ch {
 	case '=':
 		tok = newToken(token.ASSIGN, l.ch)
@@ -46,11 +48,53 @@ func (l *Lexer) NextToken() token.Token{
 	case '+':
 		tok = newToken(token.PLUS, l.ch)
 	case 0:
-		tok.Literal=""
-		tok.Type=token.EOF
+		tok.Literal="";
+		tok.Type=token.EOF;
+	default:
+		if isLetter(l.ch){
+			tok.Literal = l.readIdentifier()
+			tok.Type = token.LookupIdent(tok.Literal)
+			return tok
+		} else if isDigit(l.ch){
+			tok.Type = token.INT
+			tok.Literal = l.readNumber()
+			return tok
+		} else{
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
 	}
 	l.readChar()
 	return tok
+}
+
+func (l *Lexer) readIdentifier() string{
+	position := l.position
+	for isLetter(l.ch) {
+		l.readChar()
+	}
+	return l.input[position:l.position]
+}
+
+func isLetter(ch byte) bool {
+	return 'a' <= ch && ch <='z' || 'A' <= ch && ch<='Z' ||ch=='_'
+}
+
+func (l *Lexer) skipWhitespace() {
+	for l.ch == ' '|| l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
+		l.readChar()
+	}
+}
+
+func (l *Lexer) readNumber() string{
+	position := l.position
+	for isDigit(l.ch) {
+		l.readChar()
+	}
+	return l.input[position:l.position]
+}
+
+func isDigit(ch byte) bool {
+	return '0' <= ch && ch <= '9'
 }
 
 func newToken(tokenType token.TokenType, ch byte) token.Token {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -45,6 +45,17 @@ func TestNextToken2(t *testing.T){
 		x+y;
 	};
 	let result = add(five, ten);
+	!-/*5;
+	5 < 10 > 5;
+
+	if (5<10) {
+		return true;
+	} else {
+		return false;
+	}
+	
+	10 == 10;
+	10 != 9;
 	`
 
 	tests := []struct{
@@ -86,6 +97,43 @@ func TestNextToken2(t *testing.T){
 		{token.COMMA, ","},
 		{token.IDENT, "ten"},
 		{token.RPAREN, ")"},
+		{token.SEMICOLON, ";"},
+		{token.BANG, "!"},
+		{token.MINUS, "-"},
+		{token.SLASH, "/"},
+		{token.ASTERISK, "*"},
+		{token.INT, "5"},
+		{token.SEMICOLON, ";"},
+		{token.INT, "5"},
+		{token.LT, "<"},
+		{token.INT, "10"},
+		{token.GT, ">"},
+		{token.INT, "5"},
+		{token.SEMICOLON, ";"},
+		{token.IF, "if"},
+		{token.LPAREN, "("},
+		{token.INT, "5"},
+		{token.LT, "<"},
+		{token.INT, "10"},
+		{token.RPAREN, ")"},
+		{token.LBRACE, "{"},
+		{token.RETURN, "return"},
+		{token.TRUE, "true"},
+		{token.SEMICOLON, ";"},
+		{token.RBRACE, "}"},
+		{token.ELSE, "else"},
+		{token.LBRACE, "{"},
+		{token.RETURN, "return"},
+		{token.FALSE, "false"},
+		{token.SEMICOLON, ";"},
+		{token.RBRACE, "}"},
+		{token.INT, "10"},
+		{token.EQ, "=="},
+		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+		{token.INT, "10"},
+		{token.NOT_EQ, "!="},
+		{token.INT, "9"},
 		{token.SEMICOLON, ";"},
 	}
 	l := New(input)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,0 +1,38 @@
+package lexer
+
+import (
+	"monkey/token"
+	"testing"
+)
+
+func TestNextToken(t *testing.T){
+	input := `=+(){},;`
+
+	tests := []struct{
+		expectedType	token.TokenType
+		expectedLiteral	string
+	}{
+		{token.ASSIGN, "="},
+		{token.PLUS, "+"},
+		{token.LPAREN, "("},
+		{token.RPAREN, ")"},
+		{token.LBRACE, "{"},
+		{token.RBRACE, "}"},
+		{token.COMMA, ","},
+		{token.SEMICOLON,";"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q",
+				i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q",
+				i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 )
 
-func TestNextToken(t *testing.T){
+func TestNextToken(t *testing.T) {
 	input := `=+(){},;`
 
-	tests := []struct{
-		expectedType	token.TokenType
-		expectedLiteral	string
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
 	}{
 		{token.ASSIGN, "="},
 		{token.PLUS, "+"},
@@ -19,7 +19,7 @@ func TestNextToken(t *testing.T){
 		{token.LBRACE, "{"},
 		{token.RBRACE, "}"},
 		{token.COMMA, ","},
-		{token.SEMICOLON,";"},
+		{token.SEMICOLON, ";"},
 		{token.EOF, ""},
 	}
 	l := New(input)
@@ -37,7 +37,7 @@ func TestNextToken(t *testing.T){
 	}
 }
 
-func TestNextToken2(t *testing.T){
+func TestNextToken2(t *testing.T) {
 	input := `let five = 5;
 	let ten = 10;
 	
@@ -58,9 +58,9 @@ func TestNextToken2(t *testing.T){
 	10 != 9;
 	`
 
-	tests := []struct{
-		expectedType	token.TokenType
-		expectedLiteral	string
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
 	}{
 		{token.LET, "let"},
 		{token.IDENT, "five"},

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -36,3 +36,69 @@ func TestNextToken(t *testing.T){
 		}
 	}
 }
+
+func TestNextToken2(t *testing.T){
+	input := `let five = 5;
+	let ten = 10;
+	
+	let add = fn(x,y){
+		x+y;
+	};
+	let result = add(five, ten);
+	`
+
+	tests := []struct{
+		expectedType	token.TokenType
+		expectedLiteral	string
+	}{
+		{token.LET, "let"},
+		{token.IDENT, "five"},
+		{token.ASSIGN, "="},
+		{token.INT, "5"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "ten"},
+		{token.ASSIGN, "="},
+		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "add"},
+		{token.ASSIGN, "="},
+		{token.FUNCTION, "fn"},
+		{token.LPAREN, "("},
+		{token.IDENT, "x"},
+		{token.COMMA, ","},
+		{token.IDENT, "y"},
+		{token.RPAREN, ")"},
+		{token.LBRACE, "{"},
+		{token.IDENT, "x"},
+		{token.PLUS, "+"},
+		{token.IDENT, "y"},
+		{token.SEMICOLON, ";"},
+		{token.RBRACE, "}"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "result"},
+		{token.ASSIGN, "="},
+		{token.IDENT, "add"},
+		{token.LPAREN, "("},
+		{token.IDENT, "five"},
+		{token.COMMA, ","},
+		{token.IDENT, "ten"},
+		{token.RPAREN, ")"},
+		{token.SEMICOLON, ";"},
+	}
+	l := New(input)
+
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q",
+				i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q",
+				i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"monkey/repl"
+	"os"
+	"os/user"
+)
+
+func main() {
+	user, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Hello %s! This is Monkey programming language!\n",
+		user.Username)
+	fmt.Printf("Feel free to type in commands\n")
+	repl.Start(os.Stdin, os.Stdout)
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -1,0 +1,30 @@
+package repl
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"monkey/lexer"
+	"monkey/token"
+)
+
+const PROMPT = ">> "
+
+func Start(in io.Reader, out io.Writer) {
+	scanner := bufio.NewScanner(in)
+
+	for {
+		fmt.Fprintf(out, PROMPT)
+		scanned := scanner.Scan()
+		if !scanned {
+			return
+		}
+
+		line := scanner.Text()
+		l := lexer.New(line)
+
+		for tok := l.NextToken(); tok.Type != token.EOF; tok = l.NextToken() {
+			fmt.Fprintf(out, "%+v\n", tok)
+		}
+	}
+}

--- a/token/token.go
+++ b/token/token.go
@@ -1,0 +1,33 @@
+package token
+
+type TokenType string
+
+type Token struct{
+	Type TokenType
+	Literal string
+}
+
+const(
+	ILLEGAL		= "ILLEGAL"
+	EOF			= "EOF"
+
+	//식별자 + 리터럴
+	INDENT		= "INDENT"
+	INT			= "INT"
+
+	//연산자
+	ASSIGN		= "="
+	PLUS		= "+"
+
+	//구분자
+	COMMA		= ","
+	SEMICOLON	= ";"
+	LPAREN		= "("
+	RPAREN		= ")"
+	LBRACE		= "{"
+	RBRACE		= "}"
+
+	//예약어
+	FUNCTION	= "FUNCTION"
+	LET			= "LET"
+)

--- a/token/token.go
+++ b/token/token.go
@@ -2,59 +2,58 @@ package token
 
 type TokenType string
 
-type Token struct{
-	Type TokenType
+type Token struct {
+	Type    TokenType
 	Literal string
 }
 
-const(
-	ILLEGAL		= "ILLEGAL"
-	EOF			= "EOF"
+const (
+	ILLEGAL = "ILLEGAL"
+	EOF     = "EOF"
 
 	//식별자 + 리터럴
-	IDENT		= "IDENT"
-	INT			= "INT"
-	
+	IDENT = "IDENT"
+	INT   = "INT"
+
 	//연산자
-	ASSIGN		= "="
-	PLUS		= "+"
-	MINUS		= "-"
-	BANG		= "!"
-	ASTERISK	= "*"
-	SLASH		= "/"
+	ASSIGN   = "="
+	PLUS     = "+"
+	MINUS    = "-"
+	BANG     = "!"
+	ASTERISK = "*"
+	SLASH    = "/"
 
-	LT			= "<"
-	GT			= ">"
+	LT = "<"
+	GT = ">"
 
-	EQ			= "=="
-	NOT_EQ		= "!="
+	EQ     = "=="
+	NOT_EQ = "!="
 
 	//구분자
-	COMMA		= ","
-	SEMICOLON	= ";"
-	LPAREN		= "("
-	RPAREN		= ")"
-	LBRACE		= "{"
-	RBRACE		= "}"
+	COMMA     = ","
+	SEMICOLON = ";"
+	LPAREN    = "("
+	RPAREN    = ")"
+	LBRACE    = "{"
+	RBRACE    = "}"
 
 	//예약어
-	FUNCTION	= "FUNCTION"
-	LET			= "LET"
-	TRUE		= "TRUE"
-	FALSE		= "FALSE"
-	IF			= "IF"
-	ELSE		= "ELSE"
-	RETURN		= "RETURN"
-
+	FUNCTION = "FUNCTION"
+	LET      = "LET"
+	TRUE     = "TRUE"
+	FALSE    = "FALSE"
+	IF       = "IF"
+	ELSE     = "ELSE"
+	RETURN   = "RETURN"
 )
 
 var keywords = map[string]TokenType{
-	"fn": FUNCTION,
-	"let": LET,
-	"true": TRUE,
-	"false": FALSE,
-	"if": IF,
-	"else": ELSE,
+	"fn":     FUNCTION,
+	"let":    LET,
+	"true":   TRUE,
+	"false":  FALSE,
+	"if":     IF,
+	"else":   ELSE,
 	"return": RETURN,
 }
 

--- a/token/token.go
+++ b/token/token.go
@@ -12,7 +12,7 @@ const(
 	EOF			= "EOF"
 
 	//식별자 + 리터럴
-	INDENT		= "INDENT"
+	IDENT		= "IDENT"
 	INT			= "INT"
 
 	//연산자
@@ -31,3 +31,15 @@ const(
 	FUNCTION	= "FUNCTION"
 	LET			= "LET"
 )
+
+var keywords = map[string]TokenType{
+	"fn": FUNCTION,
+	"let": LET,
+}
+
+func LookupIdent(ident string) TokenType {
+	if tok, ok := keywords[ident]; ok {
+		return tok
+	}
+	return IDENT
+}

--- a/token/token.go
+++ b/token/token.go
@@ -14,10 +14,20 @@ const(
 	//식별자 + 리터럴
 	IDENT		= "IDENT"
 	INT			= "INT"
-
+	
 	//연산자
 	ASSIGN		= "="
 	PLUS		= "+"
+	MINUS		= "-"
+	BANG		= "!"
+	ASTERISK	= "*"
+	SLASH		= "/"
+
+	LT			= "<"
+	GT			= ">"
+
+	EQ			= "=="
+	NOT_EQ		= "!="
 
 	//구분자
 	COMMA		= ","
@@ -30,11 +40,22 @@ const(
 	//예약어
 	FUNCTION	= "FUNCTION"
 	LET			= "LET"
+	TRUE		= "TRUE"
+	FALSE		= "FALSE"
+	IF			= "IF"
+	ELSE		= "ELSE"
+	RETURN		= "RETURN"
+
 )
 
 var keywords = map[string]TokenType{
 	"fn": FUNCTION,
 	"let": LET,
+	"true": TRUE,
+	"false": FALSE,
+	"if": IF,
+	"else": ELSE,
+	"return": RETURN,
 }
 
 func LookupIdent(ident string) TokenType {


### PR DESCRIPTION
# Interpreter in go

## 1장 렉싱

### 어휘분석

소스코드를 더 작업하기 쉬운 다른 형태로 표현해야한다.

소스코드 → 토큰 → 추상 구문트리

1) 소스코드 → 토큰의 열

이런 작업을 lexing(어휘 분석)이라고 부른다.

이 작업은 lexer라는 녀석이 수행한다.

토큰은 자체로 쉽게 분류할 수 있는 작은 자료구조이다.

2) 토큰 → 추상구문트리

이 작업은 토큰을 파서에 넣었을 때 일어난다.

파서는 전달받은 토큰의 열을 추상구문트리로 바꾼다.

```c
let x = 5+5;
```

이런 내용을 렉서에 넣었다고 했을 때,

```c
[
	LET,
	IDENTIFIER("x"),
	EQUAL_SIGN,
	INTEGER(5),
	PLUS_SIGN,
	INTEGER(5),
	SEMICOLON
]
```

이런 결과물을 출력한다.

- 모든 토큰에는 원본 소스코드 표현이 부착되어있다.
    - LET에는 let이, PLUS_SIGN에는 “+”가 부착되어있다.
- IDENTIFIER와 INTEGER 같은 몇몇 토큰에는 구체적인 값도 들어있다.
    - IDENTIFIER “x”에는 10이 부착되어있다.
- 정확히 토큰을 어떻게 구성할지는 렉서 구현에 따라 다르다.
    - 어떤 렉서는 파싱 단계에서 “5”를 정수로 변환하는 정도에서 그친다. 혹은 더 늦게 변환하거나, 토큰 구성시점에서는 아예 변환하지 않기도 한다.
- 렉서가 공백문자를 토큰으로 만들지 않는다.
    - 공백은 그저 토큰 사이의 구분자일 뿐이다.
    - 다만, 파이썬처럼 공백이 중요한 언어는, 렉서가 공백문자를 토큰으로 변환할 피룡가 있다.
- 상용 렉서는 행번호, 열번호, 파일이름 등을 토큰에 부착한다.
    - 부착하는 이유는 이후에 수행할 파싱단계에서 좀 더 쓸만한 에러메세지를 출력하기 위해서이다.

### 토큰 정의하기

렉서를 구현하기 위해 첫번째로 할 일은 렉서가 만드는 결과물인 토큰을 정의하는 것이다. 토큰을 몇개 정의하는것으로 시작해, 렉서를 확장할 때 마다 토큰을 추가할 것이다.

가장 먼저 렉싱할 내용을 살펴보자.

```c
let five = 5;
let ten = 10;

let add = fn(x,y){
	x+y;
};

let result = add(five, ten);
```

위의 샘플 코드에서 나올 수 있는 토큰은 다음과 같다.

- 5, 10과 같은 숫자
    - 정수타입
    - 렉서나 파서는 이게 숫자라는 것만 알면 된다.
- x, y, result와 같은 변수 이름
    - 렉서나 파서는 이게 변수이름 = 식별자라는 사실만 알면 된다.
- fn, let
    - 식별자가 아닌 이미 언어의 일부인 단어들을 예약어라고 한다.
    - 식별자와 예약어는 같은 타입으로 묶지 않는다. → 파싱단계에서 차이를 만들기 위함이다.
- (, ), {, }, =, , , ;과 같은 특수 문자
    - 이 또한 식별자와 다르게 처리할 것이다. 소스코드에 특수문자가 있냐 없냐는 매우 큰 차이를 만들어낸다.